### PR TITLE
fix(gh-actions): separate day for weekly daily-fundamentals and run-dagster

### DIFF
--- a/.github/workflows/prod__run-dagster.yaml
+++ b/.github/workflows/prod__run-dagster.yaml
@@ -2,7 +2,7 @@ name: prod__run-dagster
 
 on:
   schedule:
-    - cron: '0 5 * * 3,6'
+    - cron: '0 5 * * 4,0'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Motherduck started throttling Saturday morning, when I had two GH Actions workflows running: run-dagster and (the weekly backfill) of daily-fundamentals. By switching run-dagster to run on Thursdays and Sundays instead, we avoid using more than necessary of Motherduck compute on the same day (Saturday morning).

